### PR TITLE
resalloc-aws-minimal-spot-zone helper

### DIFF
--- a/bin/resalloc-aws-minimal-spot-zone
+++ b/bin/resalloc-aws-minimal-spot-zone
@@ -1,0 +1,35 @@
+#! /usr/bin/python3
+
+import boto3
+import argparse
+
+
+def _arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--region", required=True)
+    parser.add_argument("--instance-type", required=True)
+    return parser
+
+
+def _zone_names(client):
+    for z in client.describe_availability_zones()['AvailabilityZones']:
+        if z['State'] == 'available':
+            yield z['ZoneName']
+
+
+def _main():
+    opts = _arg_parser().parse_args()
+    client = boto3.client('ec2', region_name=opts.region)
+    for zone in _zone_names(client):
+        try:
+            price = client.describe_spot_price_history(
+                InstanceTypes=[opts.instance_type], MaxResults=1,
+                ProductDescriptions=["Linux/UNIX"],
+                AvailabilityZone=zone,
+            )['SpotPriceHistory'][0]['SpotPrice']
+
+            print("%s: %s" % (zone, price))
+        except IndexError: pass
+
+if __name__ == "__main__":
+    _main()

--- a/resalloc-aws.spec
+++ b/resalloc-aws.spec
@@ -45,6 +45,7 @@ mkdir -p %{buildroot}%{_bindir}
 install -p -m 0755 bin/resalloc-aws-new %{buildroot}%{_bindir}
 install -p -m 0755 bin/resalloc-aws-delete %{buildroot}%{_bindir}
 install -p -m 0755 bin/resalloc-aws-list %{buildroot}%{_bindir}
+install -p -m 0755 bin/resalloc-aws-minimal-spot-zone %{buildroot}%{_bindir}
 install -p -m 0755 %{name}-wait-for-ssh %{buildroot}%{_bindir}/resalloc-aws-wait-for-ssh
 
 
@@ -54,6 +55,7 @@ install -p -m 0755 %{name}-wait-for-ssh %{buildroot}%{_bindir}/resalloc-aws-wait
 %{_bindir}/%{name}-delete
 %{_bindir}/%{name}-new
 %{_bindir}/%{name}-list
+%{_bindir}/%{name}-minimal-spot-zone
 %{_bindir}/%{name}-wait-for-ssh
 
 


### PR DESCRIPTION
Just example helper for now, not used at runtime, no stable API! $ resalloc-aws-minimal-spot-zone --region us-east-1 --instance-type i4i.large us-east-1b: 0.057400
us-east-1c: 0.060600
us-east-1d: 0.073400
us-east-1e: 0.066500
us-east-1f: 0.054600