### PR TITLE
resalloc-aws-list: no need to double-kill "shutting-down" instances

### DIFF
--- a/bin/resalloc-aws-list
+++ b/bin/resalloc-aws-list
@@ -97,7 +97,8 @@ test -z "$opt_aws_profile" && fatal_args '--aws-profile required'
 test -z "$opt_pool" && fatal_args '$RESALLOC_POOL_ID or --pool required'
 
 tagsep=
-filters=(--filters 'Name=instance-state-name,Values=running,pending,shutting-down,stopping,stopped')
+# don't list: shutting-down, terminated
+filters=(--filters 'Name=instance-state-name,Values=running,pending,stopping,stopped')
 tagspec_result=()
 tag_found=false
 for tag in "${opt_tag[@]}"; do


### PR DESCRIPTION
It just needs some time.  There still was a race condition between `cmd_delete` and the subsequent `cmd_list` call that triggered additional `cmd_delete` call (at that time the instance could already be terminated).