### PR TITLE
resalloc-aws-new: run playbook with stdin=/dev/null

### DIFF
--- a/bin/resalloc-aws-new
+++ b/bin/resalloc-aws-new
@@ -321,7 +321,7 @@ run_cmd "$scriptdir/resalloc-aws-wait-for-ssh" \
 if test -n "$opt_playbook"; then
     playbook_opts=()
     $opt_initial_preparation && playbook_opts+=( "-e" "prepare_base_image=1" )
-    run_cmd ansible-playbook -i "$ip_address," "$opt_playbook" "${playbook_opts[@]}" >&2
+    run_cmd ansible-playbook -i "$ip_address," "$opt_playbook" "${playbook_opts[@]}" >&2 </dev/null
 fi
 
 if $opt_create_snapshot_image; then


### PR DESCRIPTION
This is the way around weird F39+ bug causing ansible-playbook failure:
ERROR: Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: <stdin>

Fixes: https://github.com/fedora-copr/copr/issues/3018